### PR TITLE
Delete redundant quotes.

### DIFF
--- a/src/main/java/ru/yandex/jenkins/plugins/debuilder/DebianPackageBuilder.java
+++ b/src/main/java/ru/yandex/jenkins/plugins/debuilder/DebianPackageBuilder.java
@@ -119,9 +119,9 @@ public class DebianPackageBuilder extends Builder {
 			}
 
 			runner.runCommand("cd ''{0}'' && sudo /usr/lib/pbuilder/pbuilder-satisfydepends --control control", remoteDebian);
-			String package_command = String.format("cd ''%1$s'' && debuild --check-dirname-level 0 --no-tgz-check ", remoteDebian);
+			String package_command = String.format("cd '%1$s' && debuild --check-dirname-level 0 --no-tgz-check ", remoteDebian);
 			if (signPackage) {
-				package_command += String.format("-k%1$s -p''gpg --no-tty --passphrase %2$s''", getDescriptor().getAccountEmail(), getDescriptor().getPassphrase());
+				package_command += String.format("-k%1$s -p'gpg --no-tty --passphrase %2$s'", getDescriptor().getAccountEmail(), getDescriptor().getPassphrase());
 			}
 			else
 			{


### PR DESCRIPTION
Fixes #21. Since we now use String.format instead of MessageFormat extra single quotes are redundant. 
