### PR TITLE
Change default path for dupload

### DIFF
--- a/src/main/java/ru/yandex/jenkins/plugins/debuilder/DebianPackagePublisher.java
+++ b/src/main/java/ru/yandex/jenkins/plugins/debuilder/DebianPackagePublisher.java
@@ -128,7 +128,7 @@ public class DebianPackagePublisher extends Recorder implements Serializable {
 		duploadConf.touch(System.currentTimeMillis()/1000);
 		duploadConf.write(conf, "UTF-8");
 
-		// Check if user home dir exists
+		// dupload reads configuration from system-wide settings in /etc/dupload.conf and overrides it by ~/.dupload.conf if the latter exists.
 		String moveDupload =
 				"if [ -e $HOME ]; then\n" +
 				"\tmv ''{0}'' \"$HOME/.dupload.conf\"\n" +


### PR DESCRIPTION
In current version plugin always stores dupload file in /etc. This solution has several flaws.
- Build robot must have admin right for `mv` operation (potentially, dangerous).
- This config will be override by config in ~/.dupload (if exists).

I change this logic:
- If build robot has home dir, plugin stores config in ~/.dupload.
- Otherwise, stores it in /etc/dupload.
