### PR TITLE
Add an option to append a string at the end of a version.

### DIFF
--- a/src/main/java/ru/yandex/jenkins/plugins/debuilder/ChangesExtractor.java
+++ b/src/main/java/ru/yandex/jenkins/plugins/debuilder/ChangesExtractor.java
@@ -35,14 +35,14 @@ public class ChangesExtractor {
 	public static List<Change> getChanges(AbstractBuild build, Runner runner, SCM scm, String remoteDebian, String ourMessage, VersionHelper helper) throws DebianizingException, InterruptedException {
 		BuildListener listener = runner.getListener();
 		if (scm instanceof SubversionSCM) {
-			String oldRevision = helper.getRevision();
-			helper.setRevision(getSVNRevision(build, runner, (SubversionSCM) scm, remoteDebian));
-			if ("".equals(oldRevision)) {
+			String oldUpstreamVersion = helper.getUpstreamVersion();
+			helper.setUpstreamVersion(getSVNRevision(build, runner, (SubversionSCM) scm, remoteDebian));
+			if ("".equals(oldUpstreamVersion)) {
 				runner.announce("No last revision known, using changes since last successful build to populate debian/changelog");
 				return getChangesSinceLastBuild(build, ourMessage);
 			} else {
-				runner.announce("Calculating changes since revision {0}.", oldRevision);
-				return getChangesFromSubversion(build, runner, (SubversionSCM) scm, remoteDebian, oldRevision, helper.getRevision(), ourMessage);
+				runner.announce("Calculating changes since revision {0}.", oldUpstreamVersion);
+				return getChangesFromSubversion(build, runner, (SubversionSCM) scm, remoteDebian, oldUpstreamVersion, helper.getUpstreamVersion(), ourMessage);
 			}
 		} else if (scm instanceof GitSCM) {
 			runner.announce("Calculating changes from git log");

--- a/src/main/java/ru/yandex/jenkins/plugins/debuilder/VersionHelper.java
+++ b/src/main/java/ru/yandex/jenkins/plugins/debuilder/VersionHelper.java
@@ -4,9 +4,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import jedi.functional.FunctionalPrimitives;
-
-
 /**
  * Encapsulates version information and helps with manipulation
  *
@@ -14,115 +11,88 @@ import jedi.functional.FunctionalPrimitives;
  *
  */
 public class VersionHelper {
-	private final String separator;
-	private final List<String> versionElements;
-	private final int minorEntry;
-	private final int revisionEntry;
+	private String epoch;
+	private String upstreamVersion;
+	private String debianRevision;
 
 	/**
-	 * As {@link VersionHelper#VersionHelper(String, char)} with "." separator
+	 * Constructs new helper with given version.
+	 * Version is splitted by epoch:upstreamVersion-debianRevision
+	 * As explain here: https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
 	 * @param version
 	 */
 	public VersionHelper(String version) {
-		this(version, '.');
-	}
-
-	/**
-	 * As {@link VersionHelper#VersionHelper(String[], String)} with elements got by splitting string with given character.
-	 * @param version
-	 * @param separatorCharacter
-	 */
-	public VersionHelper(String version, char separatorCharacter) {
-		this(version.split("\\" + separatorCharacter), "" + separatorCharacter);
-
-	}
-
-	/**
-	 * Constructs new helper with given version elements.
-	 * They are analyzed to know which are responsible for the minor version and for the revision.
-	 * @param versionElements
-	 */
-	public VersionHelper(String[] versionElements, String separator) {
-		this.versionElements = new ArrayList<String>(Arrays.asList(versionElements));
-		this.separator = separator;
-		this.minorEntry = getMinorEntry();
-		this.revisionEntry = getRevisionEntry();
-	}
-
-	private int getMinorEntry() {
-		int lastNumeric = -1;
-
-		for (int i = versionElements.size() - 1; i >= 0; i--) {
-			try {
-				Integer.parseInt(versionElements.get(i));
-				lastNumeric = i;
-				break;
-			} catch (NumberFormatException e) {
-				// pass
-			}
-		}
-
-		return lastNumeric;
-	}
-
-	private int getRevisionEntry() {
-		for (int i = 0; i < versionElements.size() ; i++) {
-			if (versionElements.get(i).startsWith("r")) {
-				return i;
-			}
-		}
-
-		return -1;
-	}
-
-	public void setRevision(String revision) {
-		String revisionElement = "r" + revision;
-		if (revisionEntry >= 0) {
-			versionElements.set(revisionEntry, revisionElement);
+		int epochIndex = version.indexOf(':');
+		if (epochIndex != -1) {
+			this.epoch = version.substring(0, epochIndex);
+			version = version.substring(epochIndex + 1);
 		} else {
-			versionElements.add(revisionElement);
+			this.epoch = null;
 		}
+		int debianRevisionIndex = version.lastIndexOf('-');
+		if (debianRevisionIndex != -1) {
+			this.debianRevision = version.substring(debianRevisionIndex + 1);
+			version = version.substring(0,debianRevisionIndex);
+		} else {
+			this.debianRevision = null;
+		}
+		this.upstreamVersion = version;
 	}
 
 	/**
-	 * @return last revision imprinted in this version or <b>empty string</b> if no revision known
+	 * Constructs new helper with given epoch, upstream version and debian revision.
+	 * @param epoch
+	 * @param upstreamVersion
+	 * @param debianRevision
 	 */
-	public String getRevision() {
-		if (revisionEntry >= 0) {
-			return versionElements.get(revisionEntry).substring(1);
-		} else {
-			return "";
-		}
+	public VersionHelper(String epoch, String upstreamVersion, String debianRevision) {
+		this.epoch = epoch;
+		this.upstreamVersion = upstreamVersion;
+		this.debianRevision = debianRevision;
+	}
+
+  /**
+	* @return upstreamVersion
+	*/
+	public String getUpstreamVersion() {
+		return this.upstreamVersion;
 	}
 
 	/**
-	 * @return last minor version imprinted in this version or <b>0</b> if no minor version known
-	 */
-	public int getMinorVersion() {
-		if (minorEntry >= 0) {
-			return Integer.parseInt(versionElements.get(minorEntry));
-		} else {
-			return 0;
-		}
+	* Replace upstreamVersion.
+	* @param newUpstreamVersion
+	*/
+	public void setUpstreamVersion(String newUpstreamVersion) {
+		this.upstreamVersion = newUpstreamVersion;
 	}
 
 	/**
-	 * Replace the last numeric element.
-	 * If there is no numeric element, add the new version at the end.
-	 * @param newVersion
-	 *            The new minor version
+	 * @return debian revision
 	 */
-	public void setMinorVersion(int newVersion) {
-		String versionElement = Integer.toString(newVersion);
-		if (minorEntry >= 0) {
-			versionElements.set(minorEntry, versionElement);
-		} else {
-			versionElements.add(versionElement);
-		}
+	public String getDebianRevision() {
+		return this.debianRevision;
+	}
+
+	/**
+	 * Replace debianRevision.
+	 * @param newDebianRevision
+	 */
+	public void setDebianRevision(String newDebianRevision) {
+		this.debianRevision = newDebianRevision;
 	}
 
 	public String toString() {
-		return FunctionalPrimitives.join(versionElements, separator);
+		StringBuilder s = new StringBuilder();
+		if (this.epoch != null && !this.epoch.isEmpty()) {
+			s.append(this.epoch);
+			s.append(':');
+		}
+		s.append(this.upstreamVersion);
+		if (this.debianRevision != null && !this.debianRevision.isEmpty()) {
+			s.append('-');
+			s.append(this.debianRevision);
+		}
+		return s.toString();
 	}
 
 }

--- a/src/main/resources/ru/yandex/jenkins/plugins/debuilder/DebianPackageBuilder/config.jelly
+++ b/src/main/resources/ru/yandex/jenkins/plugins/debuilder/DebianPackageBuilder/config.jelly
@@ -6,6 +6,11 @@
     <f:entry title="Next version of package" field="nextVersion">
       <f:textbox />
     </f:entry>
+    <f:entry title="Append to version"
+             field="appendVersion"
+             description="String to be append to your version">
+      <f:textbox />
+    </f:entry>
     <f:entry title="Build automatically even if there are no changes in the package" field="buildEvenWhenThereAreNoChanges">
       <f:checkbox />
     </f:entry>

--- a/src/main/resources/ru/yandex/jenkins/plugins/debuilder/DebianPackageBuilder/help-appendVersion.html
+++ b/src/main/resources/ru/yandex/jenkins/plugins/debuilder/DebianPackageBuilder/help-appendVersion.html
@@ -1,0 +1,3 @@
+<div>
+    Useful when you want to increment a version with ~${BUILD_NUMBER} or ~ubuntu14.04.1 for example.
+</div>


### PR DESCRIPTION
Useful when you want to increment by build_number for example.

Also rewrite VersionHelper to manage debian type of version: epoch:upstreamVersion:debianVersion