### PR TITLE
Fix changelog parsing in docker env

### DIFF
--- a/src/main/java/ru/yandex/jenkins/plugins/debuilder/DebianPackageBuilder.java
+++ b/src/main/java/ru/yandex/jenkins/plugins/debuilder/DebianPackageBuilder.java
@@ -304,7 +304,7 @@ public class DebianPackageBuilder extends Builder {
 		Pattern changelogFormat = Pattern.compile("(\\w+):\\s*(.*)");
 
 		for(String row: changelogOutput.split("\n")) {
-			Matcher matcher = changelogFormat.matcher(row);
+			Matcher matcher = changelogFormat.matcher(row.trim());
 			if (matcher.matches()) {
 				 changelog.put(matcher.group(1), matcher.group(2));
 			}


### PR DESCRIPTION
Due to https://github.com/docker/docker/issues/8513 and https://github.com/jenkinsci/docker-custom-build-environment-plugin/blob/c3c2b667fcace7f3a0902432dac4b151296d9123/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java#L300 changelog parsing is broken in https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Custom+Build+Environment+Plugin -- returned rows contain extra whitespace (`\r`) that fails it.

Trim the line to fix that.